### PR TITLE
Use git LFS for *.nxs files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.nxs filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/backward_compatibility.yml
+++ b/.github/workflows/backward_compatibility.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          with: lfs
       - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          with: lfs
       - name: Set up Python ${{matrix.python_version}}
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Since we need to regenerate the nxs files quite often, we should use [git lfs](https://git-lfs.com/) in order to not blow up the repo size.