### PR TITLE
Add CITATION.cff and update pynxtools version.

### DIFF
--- a/.github/workflows/check_citation.yaml
+++ b/.github/workflows/check_citation.yaml
@@ -26,8 +26,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .
-
+        pip install .[dev]
+      
+    # Check if the CITATION.cff file is valid
+    - name: Validate CITATION.cff
+      run: |
+        cffconvert --validate
     - name: Package version
       id: package_version
       run: |

--- a/.github/workflows/check_citation.yaml
+++ b/.github/workflows/check_citation.yaml
@@ -1,6 +1,9 @@
 name: Version Check
 
 on:
+  push:
+    branches:
+      - 'main'
   pull_request:
     branches:
       - 'main'

--- a/.github/workflows/check_citation.yaml
+++ b/.github/workflows/check_citation.yaml
@@ -1,14 +1,9 @@
 name: Version Check
 
 on:
-  push:
-    tags:
-      - 'v*'
-    branches:
-      - '**'
   pull_request:
     branches:
-      - 'master'
+      - 'main'
 
 jobs:
   check-version:

--- a/.github/workflows/check_citation.yaml
+++ b/.github/workflows/check_citation.yaml
@@ -43,7 +43,7 @@ jobs:
       id: citation_version
       run: |
         # Parse the version from the CITATION.cff file)
-        CITATION_VERSION=$(grep '^cff-version:' CITATION.cff | cut -d' ' -f2)
+        CITATION_VERSION=$(grep '^version:' CITATION.cff | cut -d' ' -f2)
         echo "CITATION_VERSION=$CITATION_VERSION" >> $GITHUB_ENV
         echo "Version from CITATION.cff: $CITATION_VERSION"
 

--- a/.github/workflows/check_package_versions.yaml
+++ b/.github/workflows/check_package_versions.yaml
@@ -28,14 +28,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install .
 
-    - name: Git tag version
-      id: git_tag_version
-      run: |
-        # Extract the version from the tag (e.g., 'v1.0.0' becomes '1.0.0')
-        GIT_TAG_VERSION=${GITHUB_REF#refs/tags/v}
-        echo "GIT_TAG_VERSION=$GIT_TAG_VERSION" >> $GITHUB_ENV
-        echo "Version from Git tag: $ GIT_TAG_VERSION"
-
     - name: Package version
       id: package_version
       run: |
@@ -46,23 +38,15 @@ jobs:
     - name: Citation version
       id: citation_version
       run: |
-        # Parse the version from the CITATION.cff file (using grep or similar)
+        # Parse the version from the CITATION.cff file)
         CITATION_VERSION=$(grep '^cff-version:' CITATION.cff | cut -d' ' -f2)
         echo "CITATION_VERSION=$CITATION_VERSION" >> $GITHUB_ENV
         echo "Version from CITATION.cff: $CITATION_VERSION"
 
     - name: Compare versions
       run: |
-        if [ "$ GIT_TAG_VERSION" != "$ PACKAGE_VERSION" ]; then
-          echo "Version mismatch: Git tag version is $ GIT_TAG_VERSION, setup.py version is $ PACKAGE_VERSION"
-          exit 1
-        fi
-        if [ "$ GIT_TAG_VERSION" != "$ CITATION_VERSION" ]; then
-          echo "Version mismatch: Git tag version is $ GIT_TAG_VERSION, CITATION.cff version is $ CITATION_VERSION"
-          exit 1
-        fi
         if [ "$ PACKAGE_VERSION" != "$ CITATION_VERSION" ]; then
-          echo "Version mismatch: setup.py version is $ PACKAGE_VERSION, CITATION.cff version is $ CITATION_VERSION"
+          echo "Version mismatch: package version is $ PACKAGE_VERSION, CITATION.cff version is $ CITATION_VERSION"
           exit 1
         fi
         echo "All versions match: $ GIT_TAG_VERSION"

--- a/.github/workflows/check_package_versions.yaml
+++ b/.github/workflows/check_package_versions.yaml
@@ -1,0 +1,65 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+      - '*' # Run on all pushes, but only publish on tags
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+
+    - name: Git tag version
+      id: git_tag_version
+      run: |
+        # Extract the version from the tag (e.g., 'v1.0.0' becomes '1.0.0')
+        GIT_TAG_VERSION=${GITHUB_REF#refs/tags/v}
+        echo "GIT_TAG_VERSION=$GIT_TAG_VERSION" >> $GITHUB_ENV
+        echo "Version from Git tag: $ GIT_TAG_VERSION"
+
+    - name: Package version
+      id: package_version
+      run: |
+        PACKAGE_VERSION=$(python setup.py --version)
+        echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
+        echo "Version from setup.py: $PACKAGE_VERSION"
+
+    - name: Citation version
+      id: citation_version
+      run: |
+        # Parse the version from the CITATION.cff file (using grep or similar)
+        CITATION_VERSION=$(grep '^cff-version:' CITATION.cff | cut -d' ' -f2)
+        echo "CITATION_VERSION=$CITATION_VERSION" >> $GITHUB_ENV
+        echo "Version from CITATION.cff: $CITATION_VERSION"
+
+    - name: Compare versions
+      run: |
+        if [ "$ GIT_TAG_VERSION" != "$ PACKAGE_VERSION" ]; then
+          echo "Version mismatch: Git tag version is $ GIT_TAG_VERSION, setup.py version is $ PACKAGE_VERSION"
+          exit 1
+        fi
+        if [ "$ GIT_TAG_VERSION" != "$ CITATION_VERSION" ]; then
+          echo "Version mismatch: Git tag version is $ GIT_TAG_VERSION, CITATION.cff version is $ CITATION_VERSION"
+          exit 1
+        fi
+        if [ "$ PACKAGE_VERSION" != "$ CITATION_VERSION" ]; then
+          echo "Version mismatch: setup.py version is $ PACKAGE_VERSION, CITATION.cff version is $ CITATION_VERSION"
+          exit 1
+        fi
+        echo "All versions match: $ GIT_TAG_VERSION"
+

--- a/.github/workflows/check_package_versions.yaml
+++ b/.github/workflows/check_package_versions.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Package version
       id: package_version
       run: |
-        PACKAGE_VERSION=$(python -c "import my_package; print(my_package.__version__)")
+        PACKAGE_VERSION=$(python -c "import pynxtools-stm; print(pynxtools-stm.__version__)")
         echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
         echo "Version from __init__.py: $PACKAGE_VERSION"
 

--- a/.github/workflows/check_package_versions.yaml
+++ b/.github/workflows/check_package_versions.yaml
@@ -1,10 +1,14 @@
-name: Publish to PyPI
+name: Version Check
 
 on:
   push:
     tags:
       - 'v*'
-      - '*' # Run on all pushes, but only publish on tags
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - 'master'
 
 jobs:
   check-version:

--- a/.github/workflows/check_package_versions.yaml
+++ b/.github/workflows/check_package_versions.yaml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Compare versions
       run: |
-        if [ "$ PACKAGE_VERSION" != "$ CITATION_VERSION" ]; then
+        if [ "$PACKAGE_VERSION" != "$CITATION_VERSION" ]; then
           echo "Version mismatch: package version is $ PACKAGE_VERSION, CITATION.cff version is $ CITATION_VERSION"
           exit 1
         fi

--- a/.github/workflows/check_package_versions.yaml
+++ b/.github/workflows/check_package_versions.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Package version
       id: package_version
       run: |
-        PACKAGE_VERSION=$(python -c "import pynxtools-stm; print(pynxtools-stm.__version__)")
+        PACKAGE_VERSION=$(python -c "import pynxtools_stm; print(pynxtools_stm.__version__)")
         echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
         echo "Version from __init__.py: $PACKAGE_VERSION"
 

--- a/.github/workflows/check_package_versions.yaml
+++ b/.github/workflows/check_package_versions.yaml
@@ -39,9 +39,9 @@ jobs:
     - name: Package version
       id: package_version
       run: |
-        PACKAGE_VERSION=$(python setup.py --version)
+        PACKAGE_VERSION=$(python -c "import my_package; print(my_package.__version__)")
         echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
-        echo "Version from setup.py: $PACKAGE_VERSION"
+        echo "Version from __init__.py: $PACKAGE_VERSION"
 
     - name: Citation version
       id: citation_version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
           echo "Version from CITATION.cff: $CITATION_VERSION"
       - name: Compare versions
         run: |
-          if [ "$ GIT_TAG_VERSION" != "$ CITATION_VERSION" ]; then
+          if [ "$GIT_TAG_VERSION" != "$CITATION_VERSION" ]; then
             echo "Version mismatch: Git tag version is $ GIT_TAG_VERSION, CITATION.cff version is $ CITATION_VERSION"
             exit 1
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,26 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install build
+      - name: Git tag version
+        id: git_tag_version
+        run: |
+          # Extract the version from the tag (e.g., 'v1.0.0' becomes '1.0.0')
+          GIT_TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          echo "GIT_TAG_VERSION=$GIT_TAG_VERSION" >> $GITHUB_ENV
+          echo "Version from Git tag: $ GIT_TAG_VERSION"
+      - name: Citation version
+        id: citation_version
+        run: |
+          # Parse the version from the CITATION.cff file
+          CITATION_VERSION=$(grep '^cff-version:' CITATION.cff | cut -d' ' -f2)
+          echo "CITATION_VERSION=$CITATION_VERSION" >> $GITHUB_ENV
+          echo "Version from CITATION.cff: $CITATION_VERSION"
+      - name: Compare versions
+        run: |
+          if [ "$ GIT_TAG_VERSION" != "$ CITATION_VERSION" ]; then
+            echo "Version mismatch: Git tag version is $ GIT_TAG_VERSION, CITATION.cff version is $ CITATION_VERSION"
+            exit 1
+          fi
       - name: Build package
         run: python -m build
       - name: Publish package

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,41 @@
+cff-version: 1.0.5
+title: A pynxtools plugin for STM (Scanning Tunneling Microscopy) data readers
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Rubel
+    family-names: Mozumder
+    orcid: 'https://orcid.org/0009-0007-5926-6646'
+  - given-names: 	Yichen 
+    family-names: Jin
+    orcid: 'https://orcid.org/0000-0001-9546-1202'
+  - given-names: Florian
+    family-names: Dobener
+    orcid: 'https://orcid.org/0000-0003-1987-6224'
+  - given-names: Lukas
+    family-names: Pielsticker
+    orcid: 'https://orcid.org/0000-0001-9361-8333'
+  - given-names: Sanbrock
+    family-names: Brockhauser
+    orcid: 'https://orcid.org/0000-0002-9700-4803'
+  - given-names: Carlos-Andres
+    family-names: Palma
+    orcid: 'https://orcid.org/0000-0001-5576-8496'
+doi: 10.5281/zenodo.13799111
+repository-code: 'https://github.com/FAIRmat-NFDI/pynxtools-stm'
+url: 'https://fairmat-nfdi.github.io/pynxtools-stm/'
+abstract:
+  The pynxtools-stm is python package evolved as a plugin of pynxtools,
+  which is in turn a plugin of NOMAD. The plugin pynxtools-stm is designed 
+  to read and process the data and metadata from STM (Scanning Tunneling 
+  Microscopy) and STS (Scanning Tunneling Spectroscopy) experimental data 
+  files and connect the data to the standard schema (NXsts), designed under 
+  the NeXus data format. As the part of the data reading and processing, 
+  the plugin pynxtools-stm describes experiment setup and the details of the
+  specific measurements. Though, the plugin can be used as a standalone 
+  package, but for full benifits of the pynxtools-stm, we recommended to use
+  in research data management platform NOMAD.
+
+license: Apache-2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,7 +17,7 @@ authors:
   - given-names: Lukas
     family-names: Pielsticker
     orcid: 'https://orcid.org/0000-0001-9361-8333'
-  - given-names: Sanbrock
+  - given-names: Sandor
     family-names: Brockhauser
     orcid: 'https://orcid.org/0000-0002-9700-4803'
   - given-names: Carlos-Andres

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: "1.0.5"
+cff-version: 1.0.5
 title: A pynxtools plugin for STM (Scanning Tunneling Microscopy) data readers
 message: >-
   If you use this software, please cite it using the

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,9 +1,10 @@
-cff-version: 1.0.5
+cff-version: 1.2.0
 title: A pynxtools plugin for STM (Scanning Tunneling Microscopy) data readers
-message: >-
+message:
   If you use this software, please cite it using the
   metadata from this file.
 type: software
+version: 1.0.5
 authors:
   - given-names: Rubel
     family-names: Mozumder
@@ -23,19 +24,31 @@ authors:
   - given-names: Carlos-Andres
     family-names: Palma
     orcid: 'https://orcid.org/0000-0001-5576-8496'
-doi: 10.5281/zenodo.13799111
+  - given-names: Lev
+    family-names: Ginzburg
+    orcid: 'https://orcid.org/0000-0001-8929-1040'
+  - given-names: Tamás
+    family-names: Haraszti
+    orcid: 'https://orcid.org/0000-0002-7095-4358'
+# doi: 10.5281/zenodo.13799111
 repository-code: 'https://github.com/FAIRmat-NFDI/pynxtools-stm'
 url: 'https://fairmat-nfdi.github.io/pynxtools-stm/'
 abstract:
-  The pynxtools-stm is python package evolved as a plugin of pynxtools,
-  which is in turn a plugin of NOMAD. The plugin pynxtools-stm is designed 
-  to read and process the data and metadata from STM (Scanning Tunneling 
-  Microscopy) and STS (Scanning Tunneling Spectroscopy) experimental data 
-  files and connect the data to the standard schema (NXsts), designed under 
-  the NeXus data format. As the part of the data reading and processing, 
-  the plugin pynxtools-stm describes experiment setup and the details of the
-  specific measurements. Though, the plugin can be used as a standalone 
-  package, but for full benifits of the pynxtools-stm, we recommended to use
-  in research data management platform NOMAD.
+  The pynxtools-stm is python package evolved as a plugin of pynxtools. The 
+  plugin pynxtools-stm is designed to read and process the data, metadata 
+  and setup to the specific experiment from STM (Scanning Tunneling Microscopy)
+  and STS (Scanning Tunneling Spectroscopy) experimental data files and connect
+  the data to the standard schema, NXsts 
+  (https://fairmat-nfdi.github.io/nexus_definitions/), designed under the 
+  NeXus data format. As the part of the data reading and processing, the 
+  plugin pynxtools-stm describes experiment setup and the details of the 
+  specific measurements. The plugin can be used as a standalone package, but 
+  for full benefits of the pynxtools-stm, we recommended to use in research 
+  data management platform NOMAD(https://nomad-lab.eu/nomad-lab/).
+
+  This small project is a part of the FAIRmat project (project id 460197019) 
+  funded by the Deutsche Forschungsgemeinschaft (DFG, German Research 
+  Foundation) (https://gepris.dfg.de/gepris/projekt/460197019?language=en).
+
 
 license: Apache-2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -30,6 +30,9 @@ authors:
   - given-names: Tamás
     family-names: Haraszti
     orcid: 'https://orcid.org/0000-0002-7095-4358'
+  - given-names: Markus
+    family-names: Kühbach
+    orcid: 'https://orcid.org/0000-0002-7117-5196'
 # doi: 10.5281/zenodo.13799111
 repository-code: 'https://github.com/FAIRmat-NFDI/pynxtools-stm'
 url: 'https://fairmat-nfdi.github.io/pynxtools-stm/'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 1.0.5
+cff-version: "1.0.5"
 title: A pynxtools plugin for STM (Scanning Tunneling Microscopy) data readers
 message: >-
   If you use this software, please cite it using the
@@ -8,7 +8,7 @@ authors:
   - given-names: Rubel
     family-names: Mozumder
     orcid: 'https://orcid.org/0009-0007-5926-6646'
-  - given-names: 	Yichen 
+  - given-names: Yichen 
     family-names: Jin
     orcid: 'https://orcid.org/0000-0001-9546-1202'
   - given-names: Florian

--- a/pynxtools_stm/__init__.py
+++ b/pynxtools_stm/__init__.py
@@ -22,6 +22,7 @@ file with dat extension.
 # limitations under the License.
 #
 
+___version__ = "1.0.5"
 from pynxtools_stm.stm_file_parser import get_stm_raw_file_info
 
 # To mvake the functions available in stm module

--- a/pynxtools_stm/__init__.py
+++ b/pynxtools_stm/__init__.py
@@ -22,7 +22,7 @@ file with dat extension.
 # limitations under the License.
 #
 
-___version__ = "1.0.5"
+__version__ = "1.0.5"
 from pynxtools_stm.stm_file_parser import get_stm_raw_file_info
 
 # To mvake the functions available in stm module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "findiff",
-    "pynxtools>=0.3.3",
+    "pynxtools>=0.7.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "ruff==0.3.4",
     "pytest",
     "pip-tools",
+    "cffconvert", # To validate a CITATION.cff file 
 ]
 
 docs = [


### PR DESCRIPTION
We have found that we do not need to create GitHub action to upload and publish a GitHub repo to the Zenodo. Rather the task will be handled if the repo is added to the Zenodo under the GitHub section and give access to zenodo to publish the repo. Zenodo will use data and metadata from the `CITATION.cff` from the repo. (see this links: https://docs.github.com/en/repositories/archiving-a-github-repository/referencing-and-citing-content and discussion in GitHub issue: https://github.com/citation-file-format/citation-file-format/issues/374)

How to write a CITATION.cff: https://book.the-turing-way.org/communication/citable/citable-cff.html
To publish our repo under the FAIRmat organization, the repo owner or maintainer must have authoritative access on behalf of FAIRmat organization in zenodo.
TODO:

- [x] Need a script that checks the version mentioned in `CITATION.cff` and repo package. 
- [ ] Recheck doi
- [x] Include validation step for citation.cff file
